### PR TITLE
refactor: generic error widget button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.80
+
+- refactor: generic error widget button
+
 ## 0.0.79
 
 - fix: name initial extraction

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Release](https://img.shields.io/badge/Version-^0.0.79-success.svg?style=for-the-badge)](https://shields.io/)
+[![Release](https://img.shields.io/badge/Version-^0.0.80-success.svg?style=for-the-badge)](https://shields.io/)
 [![Maintained](https://img.shields.io/badge/Maintained-Actively-informational.svg?style=for-the-badge)](https://shields.io/)
 [![Release](https://img.shields.io/badge/Coverage-100-success.svg?style=for-the-badge)](https://shields.io/)
 
@@ -24,7 +24,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```dart
 dependencies:
-  afya_moja_core: ^0.0.79
+  afya_moja_core: ^0.0.80
 ```
 
 Alternatively, your editor might support flutter pub get. Check the docs for your editor to learn more.

--- a/lib/src/presentation/generic_error_widget.dart
+++ b/lib/src/presentation/generic_error_widget.dart
@@ -34,6 +34,7 @@ class GenericErrorWidget extends StatelessWidget {
     this.headerIconSvgUrl,
     this.padding,
     this.actionKey,
+    this.showPrimaryButton = true,
   }) : super(key: key);
 
   /// [actionText]
@@ -60,6 +61,8 @@ class GenericErrorWidget extends StatelessWidget {
   final EdgeInsets? padding;
 
   final Key? actionKey;
+
+  final bool showPrimaryButton;
 
   @override
   Widget build(BuildContext context) {
@@ -103,18 +106,19 @@ class GenericErrorWidget extends StatelessWidget {
                         textAlign: TextAlign.center,
                       ),
                       mediumVerticalSizedBox,
-                      SizedBox(
-                        width: double.infinity,
-                        height: 48,
-                        child: MyAfyaHubPrimaryButton(
-                          customRadius: 8.0,
-                          buttonKey: actionKey,
-                          buttonColor: Theme.of(context).primaryColor,
-                          textColor: Colors.white,
-                          onPressed: recoverCallback,
-                          text: actionText,
+                      if (showPrimaryButton)
+                        SizedBox(
+                          width: double.infinity,
+                          height: 48,
+                          child: MyAfyaHubPrimaryButton(
+                            customRadius: 8.0,
+                            buttonKey: actionKey,
+                            buttonColor: Theme.of(context).primaryColor,
+                            textColor: Colors.white,
+                            onPressed: recoverCallback,
+                            text: actionText,
+                          ),
                         ),
-                      ),
                     ],
                   ),
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: afya_moja_core
 description: A shared library for `afyamoja` and `myafyahub` that is responsible for rendering and exposing shared components
-version: 0.0.79
+version: 0.0.80
 homepage: https://github.com/savannahghi/afya_moja_core
 repository: https://github.com/savannahghi/afya_moja_core
 issue_tracker: https://github.com/savannahghi/afya_moja_core/issues


### PR DESCRIPTION
- make the primary button optional

![Screenshot_1649320667](https://user-images.githubusercontent.com/24954467/162158084-c368d661-8944-4ef1-bc47-5ee547a76795.png)

