### PR TITLE
chore: fix time estimate banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 0.2.12
+
+- chore: fix zero minutes banner on content
 ## 0.2.11
 
 - chore: fix broken notification filter serialization

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Release](https://img.shields.io/badge/Version-^0.2.11-success.svg?style=for-the-badge)](https://shields.io/)
+[![Release](https://img.shields.io/badge/Version-^0.2.12-success.svg?style=for-the-badge)](https://shields.io/)
 [![Maintained](https://img.shields.io/badge/Maintained-Actively-informational.svg?style=for-the-badge)](https://shields.io/)
 [![Release](https://img.shields.io/badge/Coverage-100-success.svg?style=for-the-badge)](https://shields.io/)
 
@@ -24,7 +24,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```dart
 dependencies:
-  afya_moja_core: ^0.2.11
+  afya_moja_core: ^0.2.12
 ```
 
 Alternatively, your editor might support flutter pub get. Check the docs for your editor to learn more.

--- a/lib/src/presentation/content/estimated_read_time_badge_widget.dart
+++ b/lib/src/presentation/content/estimated_read_time_badge_widget.dart
@@ -20,24 +20,31 @@ class EstimatedReadTimeBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(6.0),
-      decoration: const BoxDecoration(
-        borderRadius: BorderRadius.all(
-          Radius.circular(6.0),
-        ),
-        color: readTimeBackgroundColor,
-      ),
-      child: Text(
-        contentType == ContentType.AUDIO_VIDEO && isAudio
-            ? audioTime(estimateReadTime)
-            : contentType == ContentType.AUDIO_VIDEO
-                ? contentAudioVideoDuration(
-                    videoDuration ?? 0,
-                  )
-                : contentReadDuration(estimateReadTime),
-        style: mediumSize14Text(Colors.white).copyWith(fontSize: 12),
-      ),
-    );
+    final String time;
+    if (contentType == ContentType.AUDIO_VIDEO && isAudio) {
+      time = audioTime(estimateReadTime);
+    } else {
+      if (contentType == ContentType.AUDIO_VIDEO) {
+        time = contentAudioVideoDuration(videoDuration ?? 0);
+      } else {
+        time = contentReadDuration(estimateReadTime);
+      }
+    }
+
+    return time.startsWith('0')
+        ? const SizedBox()
+        : Container(
+            padding: const EdgeInsets.all(6.0),
+            decoration: const BoxDecoration(
+              borderRadius: BorderRadius.all(
+                Radius.circular(6.0),
+              ),
+              color: readTimeBackgroundColor,
+            ),
+            child: Text(
+              time,
+              style: mediumSize14Text(Colors.white).copyWith(fontSize: 12),
+            ),
+          );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: afya_moja_core
 description: A shared library for `ProHealth360` and `ProHealth360 Daktari` that is responsible for rendering and exposing shared components
-version: 0.2.11
+version: 0.2.12
 homepage: https://github.com/savannahghi/afya_moja_core
 repository: https://github.com/savannahghi/afya_moja_core
 issue_tracker: https://github.com/savannahghi/afya_moja_core/issues


### PR DESCRIPTION
- prevent time estimate banner from showing when estimate is zero

Signed-off-by: Byron Kimani <byronkimani@Byrons-MacBook-Pro.local>
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-08 at 16 14 32](https://user-images.githubusercontent.com/40171348/183427170-8e590938-88f7-4132-9a93-84f8ea376df2.png)
