### PR TITLE
chore: change CCC number validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.14
+
+- chore: change CCC number validator to allow 15 character CCC numbers
+
 ## 0.2.13
 
 - chore: add notifications helper functions

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Release](https://img.shields.io/badge/Version-^0.2.13-success.svg?style=for-the-badge)](https://shields.io/)
+[![Release](https://img.shields.io/badge/Version-^0.2.14-success.svg?style=for-the-badge)](https://shields.io/)
 [![Maintained](https://img.shields.io/badge/Maintained-Actively-informational.svg?style=for-the-badge)](https://shields.io/)
 [![Release](https://img.shields.io/badge/Coverage-100-success.svg?style=for-the-badge)](https://shields.io/)
 
@@ -24,7 +24,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```dart
 dependencies:
-  afya_moja_core: ^0.2.13
+  afya_moja_core: ^0.2.14
 ```
 
 Alternatively, your editor might support flutter pub get. Check the docs for your editor to learn more.

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -357,10 +357,7 @@ String? cccNumberValidator(dynamic val) {
   if (value.isEmpty) {
     return 'Your CCC number is required';
   }
-  if (!RegExp(r'^-?[0-9]+$').hasMatch(value)) {
-    return 'Only digits are allowed, 0-9';
-  }
-  if (value.length < 7 || value.length > 10) {
+  if (value.length < 7 || value.length > 15) {
     return 'Enter a valid CCC number';
   }
   return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: afya_moja_core
 description: A shared library for `ProHealth360` and `ProHealth360 Daktari` that is responsible for rendering and exposing shared components
-version: 0.2.13
+version: 0.2.14
 homepage: https://github.com/savannahghi/afya_moja_core
 repository: https://github.com/savannahghi/afya_moja_core
 issue_tracker: https://github.com/savannahghi/afya_moja_core/issues

--- a/test/unit_tests/helpers_test.dart
+++ b/test/unit_tests/helpers_test.dart
@@ -628,9 +628,8 @@ void main() {
 
   test('should return the correct error message', () {
     expect(cccNumberValidator(''), 'Your CCC number is required');
-    expect(cccNumberValidator('a'), 'Only digits are allowed, 0-9');
     expect(cccNumberValidator('123456'), 'Enter a valid CCC number');
-    expect(cccNumberValidator('012345678901'), 'Enter a valid CCC number');
+    expect(cccNumberValidator('0123456789011234'), 'Enter a valid CCC number');
     expect(cccNumberValidator('0123456789'), null);
   });
 
@@ -694,5 +693,4 @@ void main() {
       newChatMessageTitle('John', 'test group'),
     );
   });
-
 }


### PR DESCRIPTION
- change validator to allow 15 character alpha numeric CCC numbers

Signed-off-by: Byron Kimani <byronkimani@Byrons-MacBook-Pro.local>